### PR TITLE
fix undefined method empty?

### DIFF
--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -84,7 +84,7 @@ namespace :rsync do
   task sync: :'rsync:stage' do
     last_rsync_to = nil
     release_roles(:all).each do |role|
-      unless Capistrano::Configuration.env.filter(role).empty?
+      unless Capistrano::Configuration.env.filter(role).roles_array.empty?
         run_locally do
           user = "#{role.user}@" if !role.user.nil?
           rsync_options = "#{fetch(:rsync_options).join(' ')}"


### PR DESCRIPTION
Hi @linyows.

I have following errors by capistrano 3.3.5 at the rsync task.

```
** Execute rsync:sync
cap aborted!
NoMethodError: undefined method `empty?' for #<Capistrano::Configuration::Server:0x007fceaab85918>
Tasks: TOP => rsync:release => rsync:sync
The deploy has failed with an error: undefined method `empty?' for #<Capistrano::Configuration::Server:0x007fceaab85918>
** Invoke deploy:failed (first_time)
** Execute deploy:failed
```

So I using the roles_array method the array has been checked.
And I solved this error.
I was able to straighten out that problem by this correction.

Please accept this P/R if this fix has no problems.
