### PR TITLE
[FEATURE] fetch and update git submodules, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Name          | Default                                                         
 rsync_src     | tmp/deploy                                                                 | rsync src path
 rsync_dest    | shared/deploy                                                              | rsync dest path
 rsync_options | --recursive --delete --delete-excluded <br>--exclude .git* --exclude .svn* | rsync options
+rsync_with_submodules | false                                                              | fetch and update git submodules for syncing
 
 Overview
 --------


### PR DESCRIPTION
We have a git project with submodules that we want to update and deploy automatically with rsync.
So we use the --recursive switch while cloning to get all submodules, too. (works since git version 1.6.5)
If we have the cloned repo we should fetch the submodules if needed and update them to the declared version in our main repo.

That stuff is controllable via boolean switch rsync_with_submodules which defaults to false.