### PR TITLE
Shell escape string

### DIFF
--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -92,7 +92,7 @@ namespace :rsync do
           user = "#{role.user}@" if !role.user.nil?
           rsync_options = "#{fetch(:rsync_options).join(' ')}"
           rsync_from = "#{fetch(:rsync_src)}/"
-          rsync_to = "#{user}#{role.hostname}:#{fetch(:rsync_dest_fullpath) || release_path}"
+          rsync_to = Shellwords.escape("#{user}#{role.hostname}:#{fetch(:rsync_dest_fullpath) || release_path}")
 
           unless rsync_to == last_rsync_to
             execute :rsync, rsync_options, rsync_from, rsync_to

--- a/lib/capistrano/withrsync.rb
+++ b/lib/capistrano/withrsync.rb
@@ -1,5 +1,6 @@
 require 'capistrano/withrsync/version'
 require 'capistrano/withrsync/rake/task'
+require 'shellwords'
 load File.expand_path('../tasks/withrsync.rake', __FILE__)
 
 module Capistrano


### PR DESCRIPTION
We ran into a case where our username had a backlash in it & thus needed to be escaped.  Using the stdlib `Shellwords.escape` fixes this.