### PR TITLE
Fix filtering deployment destination in rsync:sync task

### DIFF
--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -85,20 +85,14 @@ namespace :rsync do
 
   desc 'Sync to deployment hosts from local'
   task sync: :'rsync:stage' do
-    last_rsync_to = nil
-    release_roles(:all).each do |role|
-      unless Capistrano::Configuration.env.filter(role).roles_array.empty?
-        run_locally do
-          user = "#{role.user}@" if !role.user.nil?
-          rsync_options = "#{fetch(:rsync_options).join(' ')}"
-          rsync_from = "#{fetch(:rsync_src)}/"
-          rsync_to = "#{user}#{role.hostname}:#{fetch(:rsync_dest_fullpath) || release_path}"
+    Capistrano::Configuration.env.filter(release_roles(:all)).each do |target|
+      run_locally do
+        user = "#{target.user}@" if !target.user.nil?
+        rsync_options = "#{fetch(:rsync_options).join(' ')}"
+        rsync_from = "#{fetch(:rsync_src)}/"
+        rsync_to = "#{user}#{target.hostname}:#{fetch(:rsync_dest_fullpath, release_path)}"
 
-          unless rsync_to == last_rsync_to
-            execute :rsync, rsync_options, rsync_from, rsync_to
-            last_rsync_to = rsync_to
-          end
-        end
+        execute :rsync, rsync_options, rsync_from, rsync_to
       end
     end
   end


### PR DESCRIPTION
When deploying with host filtering or role filtering, below exception raised in rsync:sync task.

```
(Backtrace restricted to imported tasks)
cap aborted!
NoMethodError: undefined method `roles_array' for []:Array

Tasks: TOP => rsync:release => rsync:sync
(See full trace by running task with --trace)
The deploy has failed with an error: undefined method `roles_array' for []:Array
```

https://github.com/linyows/capistrano-withrsync/blob/master/lib/capistrano/tasks/withrsync.rake#L90

Without filtering, `Capistrano::Configuration.env.filter(role)` returns `Capistrano::Configuration::Server` instance.
With filtering, it returns Array of `Capistrano::Configuration::Server` instance.

Array does not have `roles_array` method, so I think above exception raised.

I fixed code so that extract target hosts in advance insted of checking target host in `release_roles(:all).each`.

Thanks for useful gem!