### PR TITLE
Respect hosts/roles filters

### DIFF
--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -85,7 +85,8 @@ namespace :rsync do
 
   desc 'Sync to deployment hosts from local'
   task sync: :'rsync:stage' do
-    release_roles(:all).each do |server|
+    servers = Capistrano::Configuration.env.filter(release_roles(:all))
+    servers.each do |server|
       run_locally do
         user = "#{server.user}@" if !server.user.nil?
         rsync_options = "#{fetch(:rsync_options).join(' ')}"


### PR DESCRIPTION
When capistrano is invoked with --hosts/--roles options, target servers can be filtered by their hostname and roles, resp.

This patch makes `rsync:sync` task obey the behavior.