### PR TITLE
Increase clone speed of repo on big repos dramatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Options
 
 Set capistrano variables with `set name, value`.
 
-Name          | Default                                                                    | Description
-    ------------- | --------                                                                   | ------------
-rsync_src     | tmp/deploy                                                                 | rsync src path
-rsync_dest    | shared/deploy                                                              | rsync dest path
-rsync_options | --recursive --delete --delete-excluded <br>--exclude .git* --exclude .svn* | rsync options
+Name                  | Default                                                                    | Description
+-------------         | --------                                                                   | ------------
+rsync_src             | tmp/deploy                                                                 | rsync src path (it will clone a shallow copy there, make sure you do not need this repo)
+rsync_dest            | shared/deploy                                                              | rsync dest path
+rsync_options         | --recursive --delete --delete-excluded <br>--exclude .git* --exclude .svn* | rsync options
 rsync_with_submodules | false                                                              | fetch and update git submodules for syncing
 
 Overview

--- a/capistrano-withrsync.gemspec
+++ b/capistrano-withrsync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", ">= 3.1"
+  spec.add_dependency "capistrano", ">= 3.1", '<3.7'
 
   spec.add_development_dependency "bundler", "> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -63,17 +63,17 @@ namespace :rsync do
     end
   end
 
-  desc 'Empties the source for rsync'
-  task :empty_src do
+  desc 'Empties the source for rsync to allow a new clone'
+  task :delete_src do
     next unless File.directory? fetch(:rsync_src)
 
     run_locally do
-      execute :rm, '-rf' "#{fetch(:rsync_src)}/*"
+      execute :rm, '-rf', fetch(:rsync_src)
     end
   end
 
   desc 'Clone the repository in a local directory'
-  task stage: :'rsync:empty_src' do
+  task stage: :'rsync:delete_src' do
     run_locally do
       execute :git,
               :clone,
@@ -91,7 +91,7 @@ namespace :rsync do
     servers.each do |server|
       run_locally do
         user = "#{server.user}@" if !server.user.nil?
-        rsync_options = "#{fetch(:rsync_options).join(' ')}"
+        rsync_options = (fetch(:rsync_options).join(' ')).to_s
         rsync_from = "#{fetch(:rsync_src)}/"
         rsync_to = Shellwords.escape("#{user}#{server.hostname}:#{fetch(:rsync_dest_fullpath) || release_path}")
         execute :rsync, rsync_options, rsync_from, rsync_to
@@ -105,7 +105,7 @@ namespace :rsync do
 
     on release_roles :all do
       execute :rsync,
-        "#{fetch(:rsync_copy_options).join(' ')}",
+        (fetch(:rsync_copy_options).join(' ')).to_s,
         "#{fetch(:rsync_dest_fullpath)}/",
         "#{release_path}/"
     end

--- a/lib/capistrano/tasks/withrsync.rake
+++ b/lib/capistrano/tasks/withrsync.rake
@@ -63,23 +63,25 @@ namespace :rsync do
     end
   end
 
-  desc 'Create a source for rsync'
-  task :create_src do
-    next if File.directory? fetch(:rsync_src)
+  desc 'Empties the source for rsync'
+  task :empty_src do
+    next unless File.directory? fetch(:rsync_src)
 
     run_locally do
-      execute :git, :clone, ('--recursive' if fetch(:rsync_with_submodules)), fetch(:repo_url), fetch(:rsync_src)
+      execute :rm, '-rf' "#{fetch(:rsync_src)}/*"
     end
   end
 
-  desc 'Stage the repository in a local directory'
-  task stage: :'rsync:create_src' do
+  desc 'Clone the repository in a local directory'
+  task stage: :'rsync:empty_src' do
     run_locally do
-      within fetch(:rsync_src) do
-        execute :git, :fetch, ('--recurse-submodules=on-demand' if fetch(:rsync_with_submodules)), '--quiet --all --prune'
-        execute :git, :reset, "--hard origin/#{fetch(:branch)}"
-        execute :git, :submodule, :update, '--init' if fetch(:rsync_with_submodules)
-      end
+      execute :git,
+              :clone,
+              "--branch #{fetch(:branch)}",
+              '--depth 1',
+              ('--recursive --shallow-submodules' if fetch(:rsync_with_submodules)),
+              fetch(:repo_url),
+              fetch(:rsync_src)
     end
   end
 

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -31,10 +31,11 @@ describe 'task' do
     set :stage, 'test'
   end
 
-  shared_context :empty_src do
+  shared_context :must_delete_src do
     before do
+
       allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:rm, '-rf',  "#{fetch(:rsync_src)}/*")
+        with(:rm, '-rf', fetch(:rsync_src))
     end
   end
 
@@ -85,8 +86,17 @@ describe 'task' do
     end
   end
 
+  context 'on subsequent deploys' do
+    include_context :stage
+    include_context :must_delete_src
+
+    it 'should empty folder' do
+      expect(File).to receive(:directory?).with("#{fetch(:rsync_src)}").and_return(true)
+      run_task :'rsync:stage'
+    end
+  end
+
   describe 'stage' do
-    include_context :check_dir
     include_context :stage
 
     it 'sets up repository on local' do
@@ -104,7 +114,6 @@ describe 'task' do
   end
 
   describe 'sync' do
-    include_context :empty_src
     include_context :check_dir
     include_context :stage
     include_context :sync
@@ -135,7 +144,6 @@ describe 'task' do
   end
 
   describe 'release' do
-    include_context :empty_src
     include_context :check_dir
     include_context :stage
     include_context :sync

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -31,10 +31,10 @@ describe 'task' do
     set :stage, 'test'
   end
 
-  shared_context :create_src do
+  shared_context :empty_src do
     before do
       allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:git, :clone, nil, fetch(:repo_url), fetch(:rsync_src))
+        with(:rm, '-rf',  "#{fetch(:rsync_src)}/*")
     end
   end
 
@@ -48,18 +48,14 @@ describe 'task' do
   shared_context :stage do
     before do
       allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:git, :fetch, nil, '--quiet --all --prune')
-      allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:git, :reset, '--hard origin/master')
+        with(:git, :clone, '--branch master', '--depth 1', nil, fetch(:repo_url), fetch(:rsync_src))
     end
   end
 
   shared_context :stage_with_submodule do
     before do
       allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:git, :fetch, '--recurse-submodules=on-demand', '--quiet --all --prune')
-      allow_any_instance_of(SSHKit::Backend::Local).to receive(:execute).
-        with(:git, :submodule, :update, '--init')
+        with(:git, :clone, '--branch master', '--depth 1', '--recursive --shallow-submodules', fetch(:repo_url), fetch(:rsync_src))
     end
   end
 
@@ -90,7 +86,6 @@ describe 'task' do
   end
 
   describe 'stage' do
-    include_context :create_src
     include_context :check_dir
     include_context :stage
 
@@ -109,7 +104,7 @@ describe 'task' do
   end
 
   describe 'sync' do
-    include_context :create_src
+    include_context :empty_src
     include_context :check_dir
     include_context :stage
     include_context :sync
@@ -140,7 +135,7 @@ describe 'task' do
   end
 
   describe 'release' do
-    include_context :create_src
+    include_context :empty_src
     include_context :check_dir
     include_context :stage
     include_context :sync


### PR DESCRIPTION
Allow faster deployments for large projects

Using shallow clones with the depth of one to get the src repo we only 
checkout the commit we need (even on submodules). This avoids cloning
all the history just to sync one revision to the server.

refs #21 